### PR TITLE
force https

### DIFF
--- a/Hubski/Hubski.py
+++ b/Hubski/Hubski.py
@@ -3,11 +3,14 @@ from operator import itemgetter
 
 class Hubski:
     def __init__(self):
-        self.base_url = "http://api.hubski.com"
+        self.base_url = "https://api.hubski.com"
 
     def get_pub(self, id):
-        pub = requests.get(self.base_url + "/publication/" + str(id)).json()
-        return Publication(pub)
+        pub = requests.get(self.base_url + "/publication/" + str(id), 
+                           verify=False).json()
+        if pub:
+            return Publication(pub)
+        return None
 
 class Publication(object):
     def __init__(self, response):
@@ -15,3 +18,7 @@ class Publication(object):
 
     def sortByVote(self, reverse=False):
         return sorted(self.votes, key=itemgetter('id'), reverse=reverse)
+
+    def __repr__(self):
+        return "<Publication ID={}, user={}, domain={}>"\
+                  .format(self.id, self.user, self.domain)


### PR DESCRIPTION
api.hubski.com is now only https, but it has an invalid certificate. I didn't realize this for the last pull request. Fixed and actually works now. 
